### PR TITLE
fix: bump next peerDependency minimum to ^15.5.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "next": "^14.2.25 || ^15.5.14"
+        "next": "^14.2.25 || ^15.5.18"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -976,16 +976,16 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
-      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
-      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
       "cpu": [
         "arm64"
       ],
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
-      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
       "cpu": [
         "x64"
       ],
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
-      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
       "cpu": [
         "arm64"
       ],
@@ -1034,9 +1034,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
-      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
       ],
@@ -1051,9 +1051,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
-      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
       "cpu": [
         "x64"
       ],
@@ -1068,9 +1068,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
-      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
       ],
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
-      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
       "cpu": [
         "arm64"
       ],
@@ -1102,9 +1102,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
-      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
       "cpu": [
         "x64"
       ],
@@ -2061,13 +2061,13 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
-      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@next/env": "15.5.14",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -2080,14 +2080,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.14",
-        "@next/swc-darwin-x64": "15.5.14",
-        "@next/swc-linux-arm64-gnu": "15.5.14",
-        "@next/swc-linux-arm64-musl": "15.5.14",
-        "@next/swc-linux-x64-gnu": "15.5.14",
-        "@next/swc-linux-x64-musl": "15.5.14",
-        "@next/swc-win32-arm64-msvc": "15.5.14",
-        "@next/swc-win32-x64-msvc": "15.5.14",
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Vectorize",
   "license": "MIT",
   "peerDependencies": {
-    "next": "^14.2.25 || ^15.5.14"
+    "next": "^14.2.25 || ^15.5.18"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary
- Bump `next` peer dependency minimum for 15.x from `^15.5.14` to `^15.5.18`
- Updates lock file to resolve `next` 15.5.18

## Dependabot alerts resolved
- GHSA-q4gf-8mx6-v5v3 — DoS with Server Components (high)
- GHSA-492v-c6pp-mqqv — Middleware bypass via dynamic route param injection (high)
- GHSA-267c-6grr-h53f — Middleware bypass via segment-prefetch routes (high)
- GHSA-26hh-7cqf-hhc6 — Middleware bypass incomplete fix follow-up (high)

## Test plan
- [ ] Verify `npm audit` shows no new high/critical vulnerabilities
- [ ] Verify `npm run build` succeeds
- [ ] Verify Dependabot alerts close after merge